### PR TITLE
fix: guard stats loading when no Nostr key

### DIFF
--- a/src/hooks/useNostrRunStats.js
+++ b/src/hooks/useNostrRunStats.js
@@ -7,8 +7,9 @@ import { fetchEvents } from '../utils/nostr';
  * Fetches all Kind 1301 workout records for the logged-in user and returns
  * aggregated statistics plus the raw events for further UI needs.
  */
-export const useNostrRunStats = () => {
-  const { publicKey: userPubkey } = useContext(NostrContext);
+export const useNostrRunStats = (pubkeyOverride) => {
+  const { publicKey: contextPubkey } = useContext(NostrContext);
+  const userPubkey = pubkeyOverride || contextPubkey;
   const [workoutEvents, setWorkoutEvents] = useState([]);
   const [stats, setStats] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -217,10 +218,7 @@ export const useNostrRunStats = () => {
   }, [calculateWorkoutXP, calculateLevelData]);
 
   const loadEvents = useCallback(async () => {
-    if (!userPubkey) {
-      setError('No user pubkey');
-      return;
-    }
+    if (!userPubkey) return;
     setIsLoading(true);
     setError(null);
     try {
@@ -237,8 +235,10 @@ export const useNostrRunStats = () => {
   }, [userPubkey, aggregateStats]);
 
   useEffect(() => {
-    loadEvents();
-  }, [loadEvents]);
+    if (userPubkey) {
+      loadEvents();
+    }
+  }, [userPubkey, loadEvents]);
 
   return { workoutEvents, stats, isLoading, error, reload: loadEvents };
 }; 

--- a/src/pages/NostrStatsPage.jsx
+++ b/src/pages/NostrStatsPage.jsx
@@ -1,6 +1,6 @@
 import { useSettings } from '../contexts/SettingsContext';
 import { useNostrRunStats } from '../hooks/useNostrRunStats';
-import { Button } from "@/components/ui/button";
+import { useNostr } from '../hooks/useNostr';
 import LevelSystemHeader from '../components/LevelSystemHeader';
 import { useState, useMemo } from 'react';
 
@@ -64,9 +64,9 @@ const groupWorkoutsByMonth = (events) => {
     .map(([key, value]) => ({ key, ...value }));
 };
 
-const NostrStatsPage = () => {
+const NostrStatsContent = ({ pubkey }) => {
   const { distanceUnit } = useSettings(); // eslint-disable-line no-unused-vars
-  const { workoutEvents, stats, isLoading, error, reload } = useNostrRunStats();
+  const { workoutEvents, stats, isLoading, error } = useNostrRunStats(pubkey);
   const [expandedMonths, setExpandedMonths] = useState(new Set());
 
   const groupedWorkouts = useMemo(() => {
@@ -165,4 +165,10 @@ const NostrStatsPage = () => {
   );
 };
 
-export default NostrStatsPage; 
+const NostrStatsPage = () => {
+  const { publicKey } = useNostr();
+  if (!publicKey) return <p className="p-4 text-text-primary">Veuillez connecter votre clé Nostr.</p>;
+  return <NostrStatsContent pubkey={publicKey} />;
+};
+
+export default NostrStatsPage;


### PR DESCRIPTION
## Summary
- allow passing a public key override to the Nostr run stats hook
- pass connected key to stats page to avoid "No user pubkey" errors

## Testing
- `npm test` *(fails: various module and provider errors)*
- `npm run lint` *(fails: 420 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abfa805f9c832eadab7b9cc2e19430