### PR TITLE
feat: allow manual activity entry

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Runstr</string>
-    <string name="title_activity_main">Runstr</string>
+    <string name="app_name">Runs</string>
+    <string name="title_activity_main">Runs</string>
     <string name="package_name">com.example.app</string>
     <string name="custom_url_scheme">com.example.app</string>
 </resources>

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,6 +1,6 @@
 {
   "appId": "com.runstr.app",
-  "appName": "Runstr",
+  "appName": "Runs",
   "webDir": "dist",
   "plugins": {
     "StatusBar": {

--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
     <!-- Android app optimizations -->
     <link rel="manifest" href="/manifest.json" />
     <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="application-name" content="Runstr" />
+    <meta name="application-name" content="Runs" />
     <!-- iOS optimizations -->
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Runstr" />
-    <title>Runstr</title>
+    <meta name="apple-mobile-web-app-title" content="Runs" />
+    <title>Runs</title>
     
     <!-- Tailwind CSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "RUNSTR",
-  "short_name": "RUNSTR",
+  "name": "Runs",
+  "short_name": "Runs",
   "description": "Track your runs and connect with runners on Nostr",
   "start_url": "/",
   "display": "standalone",

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -36,6 +36,7 @@ const safeLazy = (importer, componentName) => {
 // Lazy load components with better error handling
 const RunTracker = safeLazy(() => import('./components/RunTracker'), 'RunTracker');
 const RunHistory = safeLazy(() => import('./pages/RunHistory'), 'RunHistory');
+const AddManualActivity = safeLazy(() => import('./pages/AddManualActivity'), 'AddManualActivity');
 const RunClub = safeLazy(() => import('./pages/RunClub'), 'RunClub');
 const Wallet = safeLazy(() => import('./pages/Wallet'), 'Wallet');
 const Music = safeLazy(() => import('./pages/Music'), 'Music');
@@ -81,6 +82,7 @@ const AppRoutes = () => {
     <Suspense fallback={<LoadingComponent />}>
       <Routes>
         <Route path="/history" element={<RunHistory />} />
+        <Route path="/add-activity" element={<AddManualActivity />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/club" element={<RunClub />} />
         <Route path="/nwc" element={<NWC />} />

--- a/src/pages/AddManualActivity.jsx
+++ b/src/pages/AddManualActivity.jsx
@@ -1,0 +1,67 @@
+import { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import runDataService, { ACTIVITY_TYPES } from '../services/RunDataService';
+import { useSettings } from '../contexts/SettingsContext';
+import { NostrContext } from '../contexts/NostrContext';
+
+const AddManualActivity = () => {
+  const navigate = useNavigate();
+  const { distanceUnit } = useSettings();
+  const { publicKey } = useContext(NostrContext);
+
+  const [type, setType] = useState(ACTIVITY_TYPES.RUN);
+  const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
+  const [distance, setDistance] = useState('');
+  const [duration, setDuration] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const dist = parseFloat(distance);
+    const dur = parseFloat(duration);
+    if (isNaN(dist) || isNaN(dur)) return;
+
+    const distanceMeters = distanceUnit === 'mi' ? dist * 1609.34 : dist * 1000;
+    const durationSeconds = dur * 60;
+
+    runDataService.saveRun({
+      activityType: type,
+      distance: distanceMeters,
+      duration: durationSeconds,
+      timestamp: new Date(date).getTime(),
+      unit: distanceUnit
+    }, publicKey);
+
+    navigate('/history');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="page-title">Add Activity</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Type</label>
+          <select value={type} onChange={e => setType(e.target.value)} className="w-full px-3 py-2 bg-bg-secondary border border-border-secondary rounded">
+            <option value={ACTIVITY_TYPES.RUN}>Run</option>
+            <option value={ACTIVITY_TYPES.WALK}>Walk</option>
+            <option value={ACTIVITY_TYPES.CYCLE}>Cycle</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Date</label>
+          <input type="date" value={date} onChange={e => setDate(e.target.value)} className="w-full px-3 py-2 bg-bg-secondary border border-border-secondary rounded" />
+        </div>
+        <div>
+          <label className="block mb-1">Distance ({distanceUnit})</label>
+          <input type="number" step="0.01" value={distance} onChange={e => setDistance(e.target.value)} className="w-full px-3 py-2 bg-bg-secondary border border-border-secondary rounded" />
+        </div>
+        <div>
+          <label className="block mb-1">Duration (minutes)</label>
+          <input type="number" step="1" value={duration} onChange={e => setDuration(e.target.value)} className="w-full px-3 py-2 bg-bg-secondary border border-border-secondary rounded" />
+        </div>
+        <button type="submit" className="w-full px-4 py-2 bg-primary text-white rounded">Save</button>
+      </form>
+    </div>
+  );
+};
+
+export default AddManualActivity;

--- a/src/pages/RunHistory.jsx
+++ b/src/pages/RunHistory.jsx
@@ -449,9 +449,15 @@ ${additionalContent ? `\n${additionalContent}` : ''}
     <div className="run-history">
       <div className="p-4 space-y-6 bg-bg-primary min-h-screen">
         <h2 className="page-title">{getActivityText('history')}</h2>
-        <div className="my-4">
-          <Link 
-            to="/nostr-stats" 
+        <div className="my-4 flex flex-col gap-2 md:flex-row">
+          <Link
+            to="/add-activity"
+            className="w-full text-center px-4 py-3 bg-bg-secondary hover:bg-bg-tertiary border border-border-secondary rounded-lg text-text-primary font-semibold transition-colors duration-150 block md:w-auto md:inline-block"
+          >
+            Add Activity
+          </Link>
+          <Link
+            to="/nostr-stats"
             className="w-full text-center px-4 py-3 bg-bg-secondary hover:bg-bg-tertiary border border-border-secondary rounded-lg text-text-primary font-semibold transition-colors duration-150 block md:w-auto md:inline-block"
           >
             Nostr Workout Record


### PR DESCRIPTION
## Summary
- add AddManualActivity page to manually log runs, walks, or cycles
- expose manual entry via /add-activity route and link from run history
- rename app to Runs across config, resources, and web metadata

## Testing
- `npm test` *(fails: Cannot parse src/tests/NostrIntegration.test.js: Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_68ade476cbf0832ea75ee25b8a01371d